### PR TITLE
perf: :zap: change method to set params for the components

### DIFF
--- a/src/modules/about/page/about.astro
+++ b/src/modules/about/page/about.astro
@@ -20,9 +20,7 @@ Astro.cookies.set("lang", lang, {
   <AboutPanel
     client:only="vue"
     class:list="h-[75dvh]"
-    lang={Astro.params.lang === "en" || Astro.params.lang === "es"
-      ? Astro.params.lang
-      : "en"}
+    lang={ lang }
   />
 </Layout>
 

--- a/src/modules/contact/page/contact.astro
+++ b/src/modules/contact/page/contact.astro
@@ -42,9 +42,7 @@ Astro.cookies.set("lang", lang, {
       </div>
       <ContactForm
         client:load
-        lang={Astro.params.lang === "en" || Astro.params.lang === "es"
-          ? Astro.params.lang
-          : "en"}
+        lang={ lang }
       />
       <div class="text-light text-xs mt-4 font-mono">
         {info.orEmail} <a


### PR DESCRIPTION
This pull request simplifies the way the language parameter is passed to components in the `about.astro` and `contact.astro` pages. Instead of using inline logic to determine the language, it now directly uses the `lang` variable, which improves readability and maintainability.

Component prop simplification:

* [`src/modules/about/page/about.astro`](diffhunk://#diff-e9c449520378a7dba86d9478cd65e000a6ac4b4239873581485af85ea564cb68L23-R23): The `lang` prop for the `AboutPanel` component is now passed directly as `lang`, removing the inline conditional logic that defaulted to "en" if the language was not "en" or "es".
* [`src/modules/contact/page/contact.astro`](diffhunk://#diff-aefcf1bb9e1f7cdf1925a642a28df6c7f896efd6782588d47b8ef3f2b07190a6L45-R45): The `lang` prop for the `ContactForm` component is now passed directly as `lang`, also removing the previous inline conditional logic.