### PR TITLE
feat: :sparkles: adding new store routes when the user change view panel or nabvar item

### DIFF
--- a/src/components/atoms/Select.vue
+++ b/src/components/atoms/Select.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="relative w-full flex justify-end select-container">
         <button type="button"
-            class="select-trigger flex items-center justify-between gap-2 bg-background text-foreground rounded-md px-4 py-2 text-base font-normal shadow-sm transition-colors min-h-[2.5rem] w-36"
+            class="select-trigger flex items-center justify-between gap-2 bg-background text-foreground rounded-md px-4 py-2 text-base font-normal shadow-sm transition-colors min-h-[2.5rem] w-36 font-FiraCode"
             @click="toggleDropdown" :aria-expanded="open ? 'true' : 'false'" :aria-controls="dropdownId">
             <span class="truncate flex-1 text-left">{{ selectedLabel || placeholder }}</span>
             <IconByName name="ChevronDown" color="dark"
@@ -14,7 +14,7 @@
                 role="listbox" @keydown.esc="closeDropdown">
                 <li v-for="option in options" :key="option.value" @click="handleChange(option.value)" role="option"
                     :aria-selected="option.value === modelValue" :class="[
-                        'px-4 py-2 text-base cursor-pointer select-none transition-colors',
+                        'px-4 py-2 text-base cursor-pointer select-none transition-colors font-FiraCode',
                         option.value === modelValue
                             ? 'bg-orangeHover/10 text-orangeHover font-semibold'
                             : 'hover:bg-orangeHover/10 hover:text-orangeHover'

--- a/src/components/molecule/AboutPanel.vue
+++ b/src/components/molecule/AboutPanel.vue
@@ -132,7 +132,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from "vue";
+import { ref, computed, onMounted, watch } from "vue";
 import IconByName from "@/components/atoms/IconByName.vue";
 import AboutInfoPanel from "@/components/molecule/AboutInfoPanel.vue";
 import { useAboutPanel } from "@/composables/aboutPanel";
@@ -175,10 +175,32 @@ const selectedGameComponent = computed(() => {
   return found ? found.component : null;
 });
 
+function getPanelFromUrl() {
+  if (typeof window === 'undefined') return null;
+  const params = new URLSearchParams(window.location.search);
+  return params.get('section');
+}
+
+function setPanelInUrl(panelKey: string) {
+  if (typeof window === 'undefined') return;
+  const url = new URL(window.location.href);
+  url.searchParams.set('section', panelKey);
+  window.history.replaceState({}, '', url.toString());
+}
+
 onMounted(() => {
-  if (activePanel.value === "terminal") {
+  const section = getPanelFromUrl();
+
+  if (section && panels.some(p => p.key === section)) {
+    activePanel.value = section;
+    onPanelOpen(section);
+  } else if (activePanel.value === "terminal") {
     onPanelOpen("terminal");
   }
+
+  watch(activePanel, (val) => {
+    setPanelInUrl(val);
+  });
 });
 </script>
 

--- a/src/components/molecule/AboutPanel.vue
+++ b/src/components/molecule/AboutPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex w-full h-[76dvh] min-h-[76dvh]">
+  <div v-if="isPanelReady" class="flex w-full h-[76dvh] min-h-[76dvh]">
     <aside
       class="flex flex-col items-center gap-6 py-8 px-2 bg-bg-background border-r border-border min-w-[80px] animate-panel-in-left"
     >
@@ -132,11 +132,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from "vue";
+import { ref, onMounted, watch } from "vue";
 import IconByName from "@/components/atoms/IconByName.vue";
 import AboutInfoPanel from "@/components/molecule/AboutInfoPanel.vue";
 import { useAboutPanel } from "@/composables/aboutPanel";
-import { TetrisMinimal, FlappyBird } from "@/components/games";
 import { useTranslations } from "@/i18n/utils";
 
 const props = defineProps<{
@@ -161,45 +160,26 @@ const {
   isJsonLine,
   getIndentLevel,
   formatJsonLine,
+  games,
+  selectedGame,
+  selectedGameComponent,
+  loadAboutPanelState,
+  saveAboutPanelState,
+  isPanelReady,
 } = useAboutPanel();
 
-const games = [
-  { key: 'tetris', label: 'Tetris', component: TetrisMinimal },
-  { key: 'flappy', label: 'Flappy Bird', component: FlappyBird },
-];
-
-const selectedGame = ref('tetris');
-const selectedGameComponent = computed(() => {
-  const found = games.find(g => g.key === selectedGame.value);
-  return found ? found.component : null;
+onMounted(() => {
+  loadAboutPanelState();
+  isPanelReady.value = true;
 });
 
-function getPanelFromUrl() {
-  if (typeof window === 'undefined') return null;
-  const params = new URLSearchParams(window.location.search);
-  return params.get('section');
-}
-
-function setPanelInUrl(panelKey: string) {
-  if (typeof window === 'undefined') return;
-  const url = new URL(window.location.href);
-  url.searchParams.set('section', panelKey);
-  window.history.replaceState({}, '', url.toString());
-}
-
-onMounted(() => {
-  const section = getPanelFromUrl();
-
-  if (section && panels.some(p => p.key === section)) {
-    activePanel.value = section;
-    onPanelOpen(section);
-  } else if (activePanel.value === "terminal") {
-    onPanelOpen("terminal");
-  }
-
-  watch(activePanel, (val) => {
-    setPanelInUrl(val);
-  });
+watch([
+  activePanel,
+  selectedGame,
+  selectedGameComponent,
+  currentCommand,
+], () => {
+  saveAboutPanelState();
 });
 </script>
 

--- a/src/components/molecule/AboutPanel.vue
+++ b/src/components/molecule/AboutPanel.vue
@@ -163,7 +163,6 @@ const {
   formatJsonLine,
 } = useAboutPanel();
 
-// --- Game selector logic ---
 const games = [
   { key: 'tetris', label: 'Tetris', component: TetrisMinimal },
   { key: 'flappy', label: 'Flappy Bird', component: FlappyBird },

--- a/src/components/molecule/ProjectsPanel.vue
+++ b/src/components/molecule/ProjectsPanel.vue
@@ -113,11 +113,6 @@ const props = defineProps<{
 const { projects: TProjects } = useTranslations(props.lang);
 const { info } = TProjects;
 
-const randomColor = () => {
-  const colors = ["red", "blue", "green", "yellow", "purple", "pink", "orange", "gray"];
-  return colors[Math.floor(Math.random() * colors.length)];
-};
-
 const {
   showFilters,
   filteredProjects,
@@ -126,55 +121,19 @@ const {
   deselectAllFrameworks,
   saveFiltersToStorage,
   loadFiltersFromStorage,
+  randomColor,
 } = usePanelProjects();
-
-function getFiltersFromUrl() {
-  if (typeof window === 'undefined') return;
-
-  const params = new URLSearchParams(window.location.search);
-  const filters = params.get('filters');
-
-  if (filters === 'open') showFilters.value = true;
-  if (filters === 'closed') showFilters.value = false;
-
-  const fw = params.get('fw');
-
-  if (fw) {
-    const active = fw.split(',');
-    frameworks.forEach(fwObj => {
-      fwObj.checked = active.includes(fwObj.key);
-    });
-  }
-}
-
-function setFiltersInUrl() {
-  if (typeof window === 'undefined') return;
-
-  const url = new URL(window.location.href);
-  url.searchParams.set('filters', showFilters.value ? 'open' : 'closed');
-
-  const activeFw = frameworks.filter(fw => fw.checked).map(fw => fw.key);
-  url.searchParams.set('fw', activeFw.join(','));
-  window.history.replaceState({}, '', url.toString());
-}
 
 watch(
   () => frameworks.map((fw) => fw.checked),
   () => {
     saveFiltersToStorage();
-    setFiltersInUrl();
   },
   { deep: true }
 );
 
-watch(showFilters, () => {
-  setFiltersInUrl();
-});
-
 onMounted(() => {
-  getFiltersFromUrl();
   loadFiltersFromStorage();
-  setFiltersInUrl();
 });
 </script>
 

--- a/src/components/molecule/ProjectsPanel.vue
+++ b/src/components/molecule/ProjectsPanel.vue
@@ -128,16 +128,53 @@ const {
   loadFiltersFromStorage,
 } = usePanelProjects();
 
+function getFiltersFromUrl() {
+  if (typeof window === 'undefined') return;
+
+  const params = new URLSearchParams(window.location.search);
+  const filters = params.get('filters');
+
+  if (filters === 'open') showFilters.value = true;
+  if (filters === 'closed') showFilters.value = false;
+
+  const fw = params.get('fw');
+
+  if (fw) {
+    const active = fw.split(',');
+    frameworks.forEach(fwObj => {
+      fwObj.checked = active.includes(fwObj.key);
+    });
+  }
+}
+
+function setFiltersInUrl() {
+  if (typeof window === 'undefined') return;
+
+  const url = new URL(window.location.href);
+  url.searchParams.set('filters', showFilters.value ? 'open' : 'closed');
+
+  const activeFw = frameworks.filter(fw => fw.checked).map(fw => fw.key);
+  url.searchParams.set('fw', activeFw.join(','));
+  window.history.replaceState({}, '', url.toString());
+}
+
 watch(
   () => frameworks.map((fw) => fw.checked),
   () => {
     saveFiltersToStorage();
+    setFiltersInUrl();
   },
   { deep: true }
 );
 
+watch(showFilters, () => {
+  setFiltersInUrl();
+});
+
 onMounted(() => {
+  getFiltersFromUrl();
   loadFiltersFromStorage();
+  setFiltersInUrl();
 });
 </script>
 

--- a/src/components/molecule/ProjectsPanel.vue
+++ b/src/components/molecule/ProjectsPanel.vue
@@ -5,7 +5,7 @@
       : 'min-w-[60px] md:min-w-[60px] items-center justify-center'
       ">
       <div class="flex items-center justify-between cursor-pointer select-none transition-transform duration-300"
-        :class="showFilters ? 'flex-row' : 'flex-col w-[20px]'" @click="showFilters = !showFilters">
+        :class="showFilters ? 'flex-row' : 'flex-col w-[20px]'" @click="toggleShowFilters">
         <div class="flex items-center gap-2" :class="showFilters ? '' : 'flex-col gap-1'">
           <Typography variant="FiraCode" as="p" color="light"
             className="font-bold transition-transform duration-300"
@@ -135,6 +135,11 @@ watch(
 onMounted(() => {
   loadFiltersFromStorage();
 });
+
+function toggleShowFilters() {
+  showFilters.value = !showFilters.value;
+  saveFiltersToStorage();
+}
 </script>
 
 <style scoped>

--- a/src/composables/panelProjects.ts
+++ b/src/composables/panelProjects.ts
@@ -1,6 +1,7 @@
 import { computed, ref } from "vue";
 import { frameworks, allProjects } from "@/stores/projects";
 
+const SHOW_FILTERS_KEY = "projectShowFilters";
 const showFilters = ref(true);
 
 const filteredProjects = computed(() => {
@@ -74,6 +75,7 @@ function saveFiltersToStorage() {
     checked: fw.checked,
   }));
   localStorage.setItem("projectFilters", JSON.stringify(filterState));
+  localStorage.setItem(SHOW_FILTERS_KEY, JSON.stringify(showFilters.value));
 }
 
 function loadFiltersFromStorage() {
@@ -90,6 +92,12 @@ function loadFiltersFromStorage() {
     } catch (error) {
       console.warn("Error loading filter state from localStorage:", error);
     }
+  }
+  const show = localStorage.getItem(SHOW_FILTERS_KEY);
+  if (show !== null) {
+    try {
+      showFilters.value = JSON.parse(show);
+    } catch {}
   }
 }
 

--- a/src/composables/panelProjects.ts
+++ b/src/composables/panelProjects.ts
@@ -51,6 +51,11 @@ const filteredProjects = computed(() => {
   });
 });
 
+const randomColor = () => {
+  const colors = ["red", "blue", "green", "yellow", "purple", "pink", "orange", "gray"];
+  return colors[Math.floor(Math.random() * colors.length)];
+};
+
 function selectAllFrameworks() {
   frameworks.forEach((fw) => (fw.checked = true));
 }
@@ -98,5 +103,6 @@ export function usePanelProjects() {
     toggleFramework,
     saveFiltersToStorage,
     loadFiltersFromStorage,
+    randomColor,
   };
 }


### PR DESCRIPTION
This pull request adds deep-linking and URL synchronization features to both the `AboutPanel` and `ProjectsPanel` components. Now, the state of which panel is open and which filters are active will be reflected in the URL, allowing users to share or bookmark specific views. The most important changes are grouped below:

**AboutPanel URL synchronization:**

* Added functions to read the active panel from the URL (`section` query param) on mount, and to update the URL whenever the active panel changes. This allows direct linking to specific panels.
* Registered a watcher on `activePanel` to keep the URL in sync with the current panel selection.
* Imported `watch` from Vue to support the new watcher functionality.

**ProjectsPanel filter deep-linking:**

* Added functions to parse filter and framework selections from the URL (`filters` and `fw` query params) on mount, and to update the URL whenever filters or frameworks change. This enables sharing and bookmarking filtered project views.
* Registered watchers on both the frameworks and the filter visibility state to keep the URL updated as the user interacts with the filters.