### PR TITLE
feat: :sparkles: adds new flag assets and updates related components

### DIFF
--- a/public/assets/flags/spain.svg
+++ b/public/assets/flags/spain.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 130 120" enable-background="new 0 0 130 120" xml:space="preserve">
+<g id="Infos">
+	<rect id="BG" x="-1250" y="-1020" fill="#D8D8D8" width="2180" height="1700"/>
+</g>
+<g id="Others">
+</g>
+<g id="Europe">
+	<g id="Row_5">
+	</g>
+	<g id="Row_4">
+		<g>
+			<rect y="0" fill="#DC4437" width="130" height="23"/>
+			<rect y="97" fill="#DC4437" width="130" height="23"/>
+			<rect y="23" fill="#FCBE1F" width="130" height="74"/>
+			<path fill="#DC4437" d="M45.3,45.8v-3h5.5v-8.2h-5.5v-6.3h-8.7v6.3h-5.5v8.2h5.5v3c-18,1-15.6,1.9-15.6,1.9v11.5V74
+				c0,0-1.2,16,20,16s20-16,20-16V59.2V47.6C61,47.6,63.3,46.8,45.3,45.8z"/>
+		</g>
+	</g>
+	<g id="Row_3">
+	</g>
+	<g id="Row_2">
+	</g>
+	<g id="Row_1">
+	</g>
+</g>
+</svg>

--- a/public/assets/flags/usa.svg
+++ b/public/assets/flags/usa.svg
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 130 120" enable-background="new 0 0 130 120" xml:space="preserve">
+<g id="Infos">
+	<rect id="BG" x="-200" y="-1350" fill="#D8D8D8" width="2180" height="1700"/>
+</g>
+<g id="Others">
+	<g>
+		<rect y="0" fill="#DC4437" width="130" height="13.3"/>
+		<rect y="26.7" fill="#DC4437" width="130" height="13.3"/>
+		<rect y="80" fill="#DC4437" width="130" height="13.3"/>
+		<rect y="106.7" fill="#DC4437" width="130" height="13.3"/>
+		<rect y="53.3" fill="#DC4437" width="130" height="13.3"/>
+		<rect y="13.3" fill="#FFFFFF" width="130" height="13.3"/>
+		<rect y="40" fill="#FFFFFF" width="130" height="13.3"/>
+		<rect y="93.3" fill="#FFFFFF" width="130" height="13.3"/>
+		<rect y="66.7" fill="#FFFFFF" width="130" height="13.3"/>
+		<rect y="0" fill="#2A66B7" width="70" height="66.7"/>
+		<polygon fill="#FFFFFF" points="13.5,4 15.8,8.9 21,9.7 17.2,13.6 18.1,19 13.5,16.4 8.9,19 9.8,13.6 6,9.7 11.2,8.9 		"/>
+		<polygon fill="#FFFFFF" points="34,4 36.3,8.9 41.5,9.7 37.8,13.6 38.6,19 34,16.4 29.4,19 30.2,13.6 26.5,9.7 31.7,8.9 		"/>
+		<polygon fill="#FFFFFF" points="54.5,4 56.8,8.9 62,9.7 58.2,13.6 59.1,19 54.5,16.4 49.9,19 50.8,13.6 47,9.7 52.2,8.9 		"/>
+		<polygon fill="#FFFFFF" points="24,24 26.3,28.9 31.5,29.7 27.8,33.6 28.6,39 24,36.4 19.4,39 20.2,33.6 16.5,29.7 21.7,28.9 		
+			"/>
+		<polygon fill="#FFFFFF" points="44.5,24 46.8,28.9 52,29.7 48.2,33.6 49.1,39 44.5,36.4 39.9,39 40.8,33.6 37,29.7 42.2,28.9 		
+			"/>
+		<polygon fill="#FFFFFF" points="13.5,45.2 15.8,50.1 21,50.9 17.2,54.7 18.1,60.2 13.5,57.6 8.9,60.2 9.8,54.7 6,50.9 11.2,50.1 
+					"/>
+		<polygon fill="#FFFFFF" points="34,45.2 36.3,50.1 41.5,50.9 37.8,54.7 38.6,60.2 34,57.6 29.4,60.2 30.2,54.7 26.5,50.9 
+			31.7,50.1 		"/>
+		<polygon fill="#FFFFFF" points="54.5,45.2 56.8,50.1 62,50.9 58.2,54.7 59.1,60.2 54.5,57.6 49.9,60.2 50.8,54.7 47,50.9 
+			52.2,50.1 		"/>
+	</g>
+</g>
+<g id="Europe">
+	<g id="Row_5">
+	</g>
+	<g id="Row_4">
+	</g>
+	<g id="Row_3">
+	</g>
+	<g id="Row_2">
+	</g>
+	<g id="Row_1">
+	</g>
+</g>
+</svg>

--- a/public/routeImg.ts
+++ b/public/routeImg.ts
@@ -41,4 +41,8 @@ export const routes = {
   gif: {
     FractalMetamorphosis2D: "videos/FractalMetamorphosis2D.gif",
   },
+  flags: {
+    us: "assets/flags/usa.svg",
+    es: "assets/flags/spain.svg"
+  }
 };

--- a/src/components/atoms/ImageByName.vue
+++ b/src/components/atoms/ImageByName.vue
@@ -26,6 +26,8 @@ const imageSrc = computed(() => {
     return modifyUrl + routes.logos[imageName as keyof typeof routes.logos];
   } else if (routes.projects[imageName as keyof typeof routes.projects]) {
     return modifyUrl + routes.projects[imageName as keyof typeof routes.projects];
+  } else if  (routes.flags[imageName as keyof typeof routes.flags]) {
+    return modifyUrl + routes.flags[imageName as keyof typeof routes.flags];
   } else {
     console.error(`Image not found for name: ${imageName}`);
     return "";

--- a/src/components/atoms/Select.vue
+++ b/src/components/atoms/Select.vue
@@ -19,7 +19,9 @@
                             ? 'bg-orangeHover/10 text-orangeHover font-semibold'
                             : 'hover:bg-orangeHover/10 hover:text-orangeHover'
                     ]">
-                    {{ option.label }}
+                    {{ option.label }} 
+                    <ImageByName v-if="option.flag" :name="option.flag" alt="Flag" fetchpriority="high"
+                        class="inline-block w-4 h-4 ml-2 align-middle" />
                 </li>
             </ul>
         </transition>
@@ -29,12 +31,13 @@
 
 <script setup lang="ts">
 import { onMounted } from 'vue';
-import IconByName from './IconByName.vue';
+import IconByName from '@/components/atoms/IconByName.vue';
 import { useSelect } from '@/composables/components';
+import ImageByName from '@/components/atoms/ImageByName.vue';
 
 const props = defineProps<{
     modelValue: string | number | null;
-    options: { label: string; value: string | number }[];
+    options: { label: string; value: string | number; flag?: string; }[];
     placeholder?: string;
 }>();
 

--- a/src/components/organism/Header.astro
+++ b/src/components/organism/Header.astro
@@ -85,8 +85,8 @@ import Toggle from "@/components/atoms/Toggle.vue";
           client:load
           modelValue={lang}
           options={[
-            { label: "English", value: "en" },
-            { label: "Español", value: "es" },
+            { label: "English", value: "en", flag: "us" },
+            { label: "Español", value: "es", flag: "es" },
           ]}
         />
       </li>


### PR DESCRIPTION
This pull request adds support for displaying country flags alongside language options in the select dropdown, enhancing the user interface for language selection. The main changes involve updating the data structure for select options, adding flag image routes, and updating components to render flag images when available.

**Support for flags in language selection:**

* Added a new `flags` object to the `routes` constant in `public/routeImg.ts`, mapping country codes to SVG flag assets.
* Updated the `options` prop in `Select.vue` to accept an optional `flag` property, and modified the language options in `Header.astro` to include the appropriate flag codes for English and Spanish. [[1]](diffhunk://#diff-50bd20d9b4c472b860ebaffaedec10c16331c76c75c1f0bd9003ccea9d51c59eL88-R89) [[2]](diffhunk://#diff-0609fc757669c5e10b01a933a4a6bdfa683ef0b48f0cb818b0d95d08f3289c33L32-R40)

**Component enhancements:**

* Modified `ImageByName.vue` to support resolving images from the new `flags` route, enabling dynamic flag image rendering.
* Updated `Select.vue` to render an `ImageByName` component next to option labels when a `flag` property is present, displaying the relevant flag in the dropdown. [[1]](diffhunk://#diff-0609fc757669c5e10b01a933a4a6bdfa683ef0b48f0cb818b0d95d08f3289c33R23-R24) [[2]](diffhunk://#diff-0609fc757669c5e10b01a933a4a6bdfa683ef0b48f0cb818b0d95d08f3289c33L32-R40)