### PR TITLE
fix: :bug: fixing issue to solve correct format on dropdown and contact

### DIFF
--- a/src/components/atoms/Select.vue
+++ b/src/components/atoms/Select.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="relative w-full flex justify-end select-container">
         <button type="button"
-            class="select-trigger flex items-center justify-between gap-2 bg-background text-foreground rounded-md px-4 py-2 text-base font-normal shadow-sm transition-colors min-h-[2.5rem] w-36 font-FiraCode"
+            class="select-trigger flex items-center justify-between gap-2 bg-background text-foreground rounded-md px-4 py-2 text-base font-normal shadow-sm transition-colors min-h-[2.5rem] w-40 font-FiraCode"
             @click="toggleDropdown" :aria-expanded="open ? 'true' : 'false'" :aria-controls="dropdownId">
             <span class="truncate flex-1 text-left">{{ selectedLabel || placeholder }}</span>
             <IconByName name="ChevronDown" color="dark"
@@ -10,7 +10,7 @@
         </button>
         <transition name="fade">
             <ul v-if="open" :id="dropdownId"
-                class="absolute right-0 z-30 mt-14 min-w-[9rem] w-36 bg-background rounded-md shadow-lg py-1 max-h-64 overflow-y-auto animate-fadeIn justify-start items-start text-start"
+                class="absolute right-0 z-30 mt-14 min-w-[9rem] w-40 bg-background rounded-md shadow-lg py-1 max-h-64 overflow-y-auto animate-fadeIn justify-start items-start text-start"
                 role="listbox" @keydown.esc="closeDropdown">
                 <li v-for="option in options" :key="option.value" @click="handleChange(option.value)" role="option"
                     :aria-selected="option.value === modelValue" :class="[

--- a/src/components/organism/Header.astro
+++ b/src/components/organism/Header.astro
@@ -85,8 +85,8 @@ import Toggle from "@/components/atoms/Toggle.vue";
           client:load
           modelValue={lang}
           options={[
-            { label: "English", value: "en", flag: "us" },
-            { label: "Español", value: "es", flag: "es" },
+            { label: "_english", value: "en", flag: "us" },
+            { label: "_español", value: "es", flag: "es" },
           ]}
         />
       </li>

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -126,18 +126,18 @@
       "description": "Contact Page"
     },
     "info": {
-      "orEmail": "Or email me at",
+      "orEmail": "or email me at",
       "joseEmail": "josehenriquez.02.26@gmail.com"
     },
     "fields": {
-      "name": "Name",
-      "namePlaceholder": "Your Name",
-      "email": "Email",
-      "emailPlaceholder": "Your Email",
-      "message": "Message",
-      "messagePlaceholder": "Your Message",
-      "send": "Send",
-      "sending": "Sending"
+      "name": "_name",
+      "namePlaceholder": "_your-name",
+      "email": "_email",
+      "emailPlaceholder": "_your-email",
+      "message": "_message",
+      "messagePlaceholder": "_your-message",
+      "send": "_send",
+      "sending": "_sending"
     }
   }
 }

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -126,18 +126,18 @@
         "description": "Página de contacto"
     },
     "info": {
-      "orEmail": "O envíame un correo a",
+      "orEmail": "o envíame un correo a",
       "joseEmail": "josehenriquez.02.26@gmail.com"
     },
     "fields": {
-      "name": "Nombre",
-      "namePlaceholder": "Tu nombre",
-      "email": "Correo electrónico",
-      "emailPlaceholder": "Tu correo electrónico",
-      "message": "Mensaje",
-      "messagePlaceholder": "Tu mensaje",
-      "send": "Enviar",
-      "sending": "Enviando"
+      "name": "_nombre",
+      "namePlaceholder": "_tu-nombre",
+      "email": "_correo-electrónico",
+      "emailPlaceholder": "_tu-correo-electrónico",
+      "message": "_mensaje",
+      "messagePlaceholder": "_tu-mensaje",
+      "send": "_enviar",
+      "sending": "_enviando"
     }
   }
 }


### PR DESCRIPTION
This pull request introduces changes to both the UI and internationalization (i18n) aspects of the project. The most notable updates are the switch to using i18n keys (with underscores) for form field labels and options, and minor UI adjustments to the `Select` component for improved appearance.

**Internationalization (i18n) updates:**

* Updated English (`en.json`) and Spanish (`es.json`) translation files to use underscored i18n keys (e.g., `_name`, `_email`) for all contact form fields and their placeholders, as well as for button text. This will require corresponding updates in the UI to display the correct translations. [[1]](diffhunk://#diff-f420468eb712a68d53557a4f5272b25a83938166b073c7ce47e0de8bd32064d7L129-R140) [[2]](diffhunk://#diff-ffd552765d922eeabc60bda1f2e8c90b5ba3c59ea616a20bf768f456c1217a87L129-R140)
* Changed language selector options in `Header.astro` to use underscored i18n keys (e.g., `_english`, `_español`) for language labels.

**UI improvements:**

* Increased the width of the `Select` component’s button and dropdown from `w-36` to `w-40` for better content display. [[1]](diffhunk://#diff-0609fc757669c5e10b01a933a4a6bdfa683ef0b48f0cb818b0d95d08f3289c33L4-R4) [[2]](diffhunk://#diff-0609fc757669c5e10b01a933a4a6bdfa683ef0b48f0cb818b0d95d08f3289c33L13-R13)
* Standardized the capitalization of the "or email me at" info string in both English and Spanish translation files for consistency. [[1]](diffhunk://#diff-f420468eb712a68d53557a4f5272b25a83938166b073c7ce47e0de8bd32064d7L129-R140) [[2]](diffhunk://#diff-ffd552765d922eeabc60bda1f2e8c90b5ba3c59ea616a20bf768f456c1217a87L129-R140)